### PR TITLE
Update version, contributors, and repo URL in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,14 +1,21 @@
 {
   "name": "multer",
   "description": "Middleware for handling `multipart/form-data`.",
-  "version": "1.4.5-lts.2",
+  "version": "1.4.5-lts.2-lineaje-01",
   "contributors": [
     "Hage Yaapa <captain@hacksparrow.com> (http://www.hacksparrow.com)",
     "Jaret Pfluger <https://github.com/jpfluger>",
-    "Linus Unnebäck <linus@folkdatorn.se>"
+    "Linus Unneb\u00e4ck <linus@folkdatorn.se>",
+    {
+      "name": "Lineaje DepFixer",
+      "email": "221268890+Lineaje-DepFixer@users.noreply.github.com"
+    }
   ],
   "license": "MIT",
-  "repository": "expressjs/multer",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lineaje-labs-gos/multer"
+  },
   "keywords": [
     "form",
     "post",


### PR DESCRIPTION
- Appended '-lineaje-01' to the version.
- Updated repository URL to point to the new repourl in lineaje-labs-gos
