### PR TITLE
Add fix for CVE-2025-7338

### DIFF
--- a/lib/make-middleware.js
+++ b/lib/make-middleware.js
@@ -89,6 +89,14 @@ function makeMiddleware (setup) {
 
     // handle files
     busboy.on('file', function (fieldname, fileStream, { filename, encoding, mimeType }) {
+      var pendingWritesIncremented = false
+
+      fileStream.on('error', function (err) {
+        if (pendingWritesIncremented) {
+          pendingWrites.decrement()
+        }
+        abortWithError(err)
+      })
       // don't attach to the files object, if there is no file
       if (!filename) return fileStream.resume()
 
@@ -118,17 +126,13 @@ function makeMiddleware (setup) {
         }
 
         var aborting = false
+        pendingWritesIncremented = true
         pendingWrites.increment()
 
         Object.defineProperty(file, 'stream', {
           configurable: true,
           enumerable: false,
           value: fileStream
-        })
-
-        fileStream.on('error', function (err) {
-          pendingWrites.decrement()
-          abortWithError(err)
         })
 
         fileStream.on('limit', function () {

--- a/test/express-integration.js
+++ b/test/express-integration.js
@@ -150,4 +150,46 @@ describe('Express Integration', function () {
     req.write(body)
     req.end()
   })
+
+  it('should not crash on malformed multipart body with bad boundary', function (done) {
+    var upload = multer()
+
+    app.post('/upload3', upload.single('image'), function (req, res) {
+      res.status(500).end('Request should not be processed')
+    })
+
+    app.use(function (err, req, res, next) {
+      assert.strictEqual(err.message, 'Unexpected end of form')
+      res.status(200).end('Correct error')
+    })
+
+    var boundary = '----FormBoundary'
+    var body = [
+      '------FormBoundary',
+      'Content-Disposition: form-data; name="image"; filename=""',
+      'Content-Type: application/octet-stream',
+      '',
+      '', // empty content
+      '------FormBoundar' // intentionally malformed final boundary (missing 'y')
+    ].join('\r\n')
+
+    var options = {
+      hostname: 'localhost',
+      port,
+      path: '/upload3',
+      method: 'POST',
+      headers: {
+        'Content-Type': 'multipart/form-data; boundary=' + boundary,
+        'Content-Length': Buffer.byteLength(body)
+      }
+    }
+
+    var req = http.request(options, (res) => {
+      assert.strictEqual(res.statusCode, 200)
+      done()
+    })
+
+    req.write(body)
+    req.end()
+  })
 })


### PR DESCRIPTION
This PR fixes a high vulnerability (CVE-2025-7338) by handling errors while parsing malformed multipart body with bad boundary

### Details

| **Field**              | **Description**                                                                                                                                          |
|------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|
| **CVE ID**             | CVE-2025-7338                                                                                       |
| **Severity**           | High                                                                                                                                                     |
| **Summary**            | Multer is a node.js middleware for handling `multipart/form-data`. A vulnerability that is present starting </br>in version 1.4.4-lts.1 and prior to version 2.0.2 allows an attacker to trigger a Denial of Service (DoS) by </br>sending a malformed multi-part upload request. This request causes an unhandled exception, leading to a </br>crash of the process. |
