### PR TITLE
Add fix for CVE-2025-47935 and CVE-2025-47944

### DIFF
--- a/lib/make-middleware.js
+++ b/lib/make-middleware.js
@@ -8,6 +8,12 @@ var MulterError = require('./multer-error')
 var FileAppender = require('./file-appender')
 var removeUploadedFiles = require('./remove-uploaded-files')
 
+function drainStream (stream) {
+  stream.on('readable', () => {
+    while (stream.read() !== null) {}
+  })
+}
+
 function makeMiddleware (setup) {
   return function multerMiddleware (req, res, next) {
     if (!is(req, ['multipart'])) return next()
@@ -21,6 +27,10 @@ function makeMiddleware (setup) {
     var preservePath = options.preservePath
 
     req.body = Object.create(null)
+
+    req.on('error', function (err) {
+      abortWithError(err)
+    })
 
     var busboy
 
@@ -41,7 +51,9 @@ function makeMiddleware (setup) {
       if (isDone) return
       isDone = true
       req.unpipe(busboy)
-      process.nextTick(() => {
+      drainStream(req)
+      req.resume()
+      setImmediate(() => {
         busboy.removeAllListeners()
       })
       next(err)

--- a/test/express-integration.js
+++ b/test/express-integration.js
@@ -192,4 +192,49 @@ describe('Express Integration', function () {
     req.write(body)
     req.end()
   })
+  it('should not crash on malformed request that causes two errors to be emitted by busboy', function (done) {
+    var upload = multer()
+
+    app.post('/upload2', upload.single('file'), function (req, res) {
+      res.status(500).end('Request should not be processed')
+    })
+
+    app.use(function (err, req, res, next) {
+      assert.strictEqual(err.message, 'Malformed part header')
+      res.status(200).end('Correct error')
+    })
+
+    var boundary = 'AaB03x'
+    // this payload causes two errors to be emitted by busboy: `Malformed part header` and `Unexpected end of form`
+    var body = [
+      '--' + boundary,
+      'Content-Disposition: form-data; name="file"; filename="test.txt"',
+      'Content-Type: text/plain',
+      '',
+      '--' + boundary + '--',
+      ''
+    ].join('\r\n')
+    var options = {
+      hostname: 'localhost',
+      port,
+      path: '/upload2',
+      method: 'POST',
+      headers: {
+        'content-type': 'multipart/form-data; boundary=' + boundary,
+        'content-length': body.length
+      }
+    }
+
+    var req = http.request(options, (res) => {
+      assert.strictEqual(res.statusCode, 200)
+      done()
+    })
+
+    req.on('error', (err) => {
+      done(err)
+    })
+
+    req.write(body)
+    req.end()
+  })
 })


### PR DESCRIPTION
This PR fixes two high vulnerability (CVE-2025-47935 and CVE-2025-47944) by handling busboy error events and request error by draining stream

### Details

| **Field**              | **Description**                                                                                                                                          |
|------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|
| **CVE ID**             | CVE-2025-47935                                                                                       |
| **Severity**           | High                                                                                                                                                     |
| **Summary**            | Multer is a node.js middleware for handling `multipart/form-data`. Versions prior to 2.0.0 are vulnerable to </br>a resource exhaustion and memory leak issue due to improper stream handling. When the HTTP request stream </br>emits an error, the internal `busboy` stream is not closed, violating Node.js stream safety guidance. This </br>leads to unclosed streams accumulating over time, consuming memory and file descriptors. Under sustained or </br>repeated failure conditions, this can result in denial of service, requiring manual server restarts to </br>recover. All users of Multer handling file uploads are potentially impacted. |

| **Field**              | **Description**                                                                                                                                          |
|------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|
| **CVE ID**             | CVE-2025-47944                                                                                       |
| **Severity**           | High                                                                                                                                                     |
| **Summary**            | Multer is a node.js middleware for handling `multipart/form-data`. A vulnerability that is present starting </br>in version 1.4.4-lts.1 and prior to version 2.0.0 allows an attacker to trigger a Denial of Service (DoS) by </br>sending a malformed multi-part upload request. This request causes an unhandled exception, leading to a </br>crash of the process. |
