### PR TITLE
Add fix for CVE-2025-48997

### DIFF
--- a/lib/make-middleware.js
+++ b/lib/make-middleware.js
@@ -109,6 +109,9 @@ function makeMiddleware (setup) {
         }
         abortWithError(err)
       })
+
+      if (fieldname == null) return abortWithCode('MISSING_FIELD_NAME')
+
       // don't attach to the files object, if there is no file
       if (!filename) return fileStream.resume()
 

--- a/test/error-handling.js
+++ b/test/error-handling.js
@@ -175,6 +175,19 @@ describe('Error Handling', function () {
     })
   })
 
+  it('should notify of missing field name', function (done) {
+    var form = new FormData()
+    var storage = multer.memoryStorage()
+    var parser = multer({ storage: storage }).single('small0')
+
+    form.append('', util.file('small0.dat'))
+
+    util.submitForm(parser, form, function (err, req) {
+      assert.strictEqual(err.code, 'MISSING_FIELD_NAME')
+      done()
+    })
+  })
+
   it('should report errors from storage engines', function (done) {
     var storage = multer.memoryStorage()
 


### PR DESCRIPTION
This PR fixes two high vulnerability (CVE-2025-48997) by handling missing field names

### Details

| **Field**              | **Description**                                                                                                                                          |
|------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|
| **CVE ID**             | CVE-2025-48997                                                                                       |
| **Severity**           | High                                                                                                                                                     |
| **Summary**            | Multer is a node.js middleware for handling `multipart/form-data`. A vulnerability that is present starting </br>in version 1.4.4-lts.1 and prior to version 2.0.1 allows an attacker to trigger a Denial of Service (DoS) by </br>sending an upload file request with an empty string field name. This request causes an unhandled exception, </br>leading to a crash of the process. |

